### PR TITLE
Add format sub command

### DIFF
--- a/format/action.go
+++ b/format/action.go
@@ -1,0 +1,43 @@
+package format
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/bketelsen/logr"
+)
+
+// DoFormat applies a format to a given input.
+func DoFormat(cfg Config, log logr.Logger) (result error) {
+	reader, err := cfg.Input()
+	if err != nil {
+		return fmt.Errorf("failed to open input: %v", err)
+	}
+
+	if closer, ok := reader.(io.Closer); ok {
+		defer closer.Close()
+	}
+
+	formats, err := cfg.Formats()
+	if err != nil {
+		return fmt.Errorf("failed to setup output formatting: %v", err)
+	}
+
+	factory := NewFactory(formats, false, log)
+	defer func() {
+		if err := factory.Close(); err != nil && result == nil {
+			result = err
+		}
+	}()
+
+	writer, err := factory.Create(0)
+	if err != nil {
+		return fmt.Errorf("failed to setup output writer: %v", err)
+	}
+
+	if _, err := io.Copy(writer, reader); nil != err {
+		result = fmt.Errorf("failed to process data: %v", err)
+	}
+
+	return
+}

--- a/format/action_test.go
+++ b/format/action_test.go
@@ -1,0 +1,90 @@
+package format_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/corvus-ch/horcrux/format"
+	"github.com/corvus-ch/horcrux/format/raw"
+	"github.com/corvus-ch/horcrux/input"
+	"github.com/corvus-ch/logr/buffered"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestFormat(t *testing.T) {
+	dir := createDir(t)
+	defer os.RemoveAll(dir)
+
+	f := raw.New(input.NewStreamInput(outputStem(dir, raw.Name)))
+	cfg := NewConfig(t.Name(), f)
+	log := buffered.New(1)
+
+	err := format.DoFormat(cfg, log)
+
+	assert.Nil(t, err)
+	mock.AssertExpectationsForObjects(t, cfg)
+
+	files, _ := filepath.Glob(fmt.Sprintf("%s.*", outputStem(dir, raw.Name)))
+
+	assert.Empty(t, log.Buf())
+	assert.Len(t, files, 1)
+}
+
+var errorTests = []struct {
+	name   string
+	setup  func(t *testing.T, cfg *Config, dir string)
+	output string
+}{
+	{"input", func(t *testing.T, cfg *Config, _ string) {
+		cfg.On("Input").Maybe().Return(nil, errors.New("input error"))
+	}, "failed to open input: input error"},
+
+	{"formats", func(t *testing.T, cfg *Config, _ string) {
+		cfg.On("Input").Return(bytes.NewBufferString(t.Name()), nil)
+		cfg.On("Formats").Return(nil, errors.New("format error"))
+	}, "failed to setup output formatting: format error"},
+
+	{"copy", func(t *testing.T, cfg *Config, dir string) {
+		f, _ := os.Open(t.Name())
+		cfg.On("Input").Return(f, nil)
+		cfg.On("InputInfo").Maybe().Return(input.NewStreamInput(outputStem(dir, raw.Name)))
+		cfg.On("Formats").Maybe().Return([]format.Format{raw.New(input.NewStreamInput(outputStem(dir, raw.Name)))}, nil)
+	}, "failed to process data: invalid argument"},
+}
+
+func TestErrors(t *testing.T) {
+	for _, test := range errorTests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := createDir(t)
+			defer os.RemoveAll(dir)
+			cfg := &Config{}
+			log := buffered.New(1)
+			test.setup(t, cfg, dir)
+
+			err := format.DoFormat(cfg, log)
+
+			assert.Error(t, err, test.output)
+			assert.Empty(t, log.Buf())
+			mock.AssertExpectationsForObjects(t, cfg)
+		})
+	}
+}
+
+func createDir(t *testing.T) string {
+	dir, err := ioutil.TempDir("", "horcrux_create")
+	if err != nil {
+		t.Error(err)
+	}
+
+	return dir
+}
+
+func outputStem(dir, format string) string {
+	return fmt.Sprintf("%s/%s", dir, format)
+}

--- a/format/config.go
+++ b/format/config.go
@@ -1,0 +1,14 @@
+package format
+
+import (
+	"io"
+
+	"github.com/corvus-ch/horcrux/input"
+)
+
+// Config define the configuration input required for creating an output format.
+type Config interface {
+	Input() (io.Reader, error)
+	InputInfo() input.Input
+	Formats() ([]Format, error)
+}

--- a/format/config_test.go
+++ b/format/config_test.go
@@ -1,0 +1,49 @@
+package format_test
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/corvus-ch/horcrux/format"
+	"github.com/corvus-ch/horcrux/input"
+	"github.com/stretchr/testify/mock"
+)
+
+type Config struct {
+	mock.Mock
+}
+
+func NewConfig(name string, f format.Format) *Config {
+	cfg := &Config{}
+	cfg.On("Input").Maybe().Return(bytes.NewBufferString(name), nil)
+	cfg.On("InputInfo").Maybe().Return(input.NewStreamInput(""))
+	cfg.On("Formats").Maybe().Return([]format.Format{f}, nil)
+
+	return cfg
+}
+
+func (c *Config) Input() (io.Reader, error) {
+	args := c.Called()
+	r := args.Get(0)
+	if r == nil {
+		return nil, args.Error(1)
+	}
+
+	return r.(io.Reader), args.Error(1)
+}
+
+func (c *Config) InputInfo() input.Input {
+	args := c.Called()
+
+	return args.Get(0).(input.Input)
+}
+
+func (c *Config) Formats() ([]format.Format, error) {
+	args := c.Called()
+	f := args.Get(0)
+	if f == nil {
+		return nil, args.Error(1)
+	}
+
+	return f.([]format.Format), args.Error(1)
+}

--- a/internal/app.go
+++ b/internal/app.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"github.com/bketelsen/logr"
 	"github.com/corvus-ch/horcrux/create"
+	"github.com/corvus-ch/horcrux/format"
 	"github.com/corvus-ch/horcrux/restore"
 	"github.com/corvus-ch/logr/writer_adapter"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -14,6 +15,7 @@ func App(log logr.Logger) *kingpin.Application {
 	app.UsageWriter(w)
 	app.ErrorWriter(w)
 	RegisterCreateCommand(app, log, create.Create)
+	RegisterFormatCommand(app, log, format.DoFormat)
 	RegisterRestoreCommand(app, log, restore.Restore)
 
 	return app

--- a/internal/app_test.go
+++ b/internal/app_test.go
@@ -15,6 +15,7 @@ var appTests = []struct {
 }{
 	{"default", []string{"help"}},
 	{"create", []string{"help", "create"}},
+	{"format", []string{"help", "format"}},
 	{"restore", []string{"help", "restore"}},
 }
 

--- a/internal/fixtures/TestApp/default.golden
+++ b/internal/fixtures/TestApp/default.golden
@@ -12,6 +12,9 @@ ERROR
 ERROR   create [<flags>] [<input>]
 ERROR     create a new set of horcruxes
 ERROR 
+ERROR   format [<flags>] [<input>]
+ERROR     formats input the same way as create would do without doing the split
+ERROR 
 ERROR   restore [<flags>] <files>...
 ERROR     restores your valuable data from a set of horcruxes
 ERROR 

--- a/internal/fixtures/TestApp/format.golden
+++ b/internal/fixtures/TestApp/format.golden
@@ -1,0 +1,13 @@
+ERROR usage: horcrux format [<flags>] [<input>]
+ERROR 
+ERROR formats input the same way as create would do without doing the split
+ERROR 
+ERROR Flags:
+ERROR       --help             Show context-sensitive help (also try --help-long and
+ERROR                          --help-man).
+ERROR   -f, --format=text ...  the output formats
+ERROR   -o, --output=OUTPUT    name stem for the output files
+ERROR 
+ERROR Args:
+ERROR   [<input>]  the input file
+ERROR 

--- a/internal/format.go
+++ b/internal/format.go
@@ -1,0 +1,94 @@
+package internal
+
+import (
+	"io"
+	"os"
+
+	"github.com/bketelsen/logr"
+	"github.com/corvus-ch/horcrux/format"
+	"github.com/corvus-ch/horcrux/input"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+type formatAction func(cfg format.Config, logger logr.Logger) error
+
+type formatCommand struct {
+	action formatAction
+
+	// The logger
+	log logr.Logger
+
+	// Arguments
+	input string
+
+	// Flags
+	formats  []string
+	stemFlag string
+
+	// internal
+	info input.Input
+}
+
+// RegisterFormatCommand registers the format sub command with the application.
+func RegisterFormatCommand(app *kingpin.Application, log logr.Logger, action formatAction) *formatCommand {
+	c := &formatCommand{action: action, log: log}
+
+	cc := app.Command("format", "formats input the same way as create would do without doing the split")
+	cc.Action(c.Execute)
+	cc.Arg("input", "the input file").
+		StringVar(&c.input)
+	cc.Flag("format", "the output formats").
+		Default(format.Default).
+		Short('f').
+		StringsVar(&c.formats)
+	cc.Flag("output", "name stem for the output files").
+		Short('o').
+		StringVar(&c.stemFlag)
+
+	return c
+}
+
+// Execute runs the action callback.
+func (c *formatCommand) Execute(_ *kingpin.ParseContext) error {
+	return c.action(c, c.log)
+}
+
+// Input returns the input file.
+func (c *formatCommand) Input() (io.Reader, error) {
+	if c.input == "-" || c.input == "" {
+		return os.Stdin, nil
+	}
+
+	return os.Open(c.input)
+}
+
+// InputInfo returns detail infor about the input.
+func (c *formatCommand) InputInfo() input.Input {
+	if c.info != nil {
+		return c.info
+	}
+
+	if c.input == "-" || c.input == "" {
+		c.info = input.NewStreamInput(c.stemFlag)
+	} else {
+
+		c.info = input.NewFileInput(c.input, c.stemFlag)
+	}
+
+	return c.info
+}
+
+// Formats returns the list of output formats to produce
+func (c *formatCommand) Formats() ([]format.Format, error) {
+	formats := make([]format.Format, len(c.formats))
+
+	for i, f := range c.formats {
+		ff, err := format.New(f, c.InputInfo())
+		if err != nil {
+			return nil, err
+		}
+		formats[i] = ff
+	}
+
+	return formats, nil
+}

--- a/internal/format_test.go
+++ b/internal/format_test.go
@@ -1,0 +1,81 @@
+package internal_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/bketelsen/logr"
+	"github.com/corvus-ch/horcrux/format"
+	"github.com/corvus-ch/horcrux/format/raw"
+	"github.com/corvus-ch/horcrux/format/text"
+	"github.com/corvus-ch/horcrux/format/zbase32"
+	"github.com/corvus-ch/horcrux/internal"
+	"github.com/corvus-ch/logr/buffered"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+func assertFormatAction(t *testing.T, args []string, action func(format.Config, logr.Logger) error) {
+	log := buffered.New(0)
+	app := kingpin.New("test", "test")
+	internal.RegisterFormatCommand(app, log, action)
+	_, err := app.Parse(args)
+	assert.Nil(t, err)
+}
+
+func TestFormatCommand_Input(t *testing.T) {
+	file, err := ioutil.TempFile("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+	tests := []struct {
+		name string
+		args []string
+		file *os.File
+	}{
+		{"default", []string{"format"}, os.Stdin},
+		{"stdin", []string{"format", "--", "-"}, os.Stdin},
+		{"file", []string{"format", "--", file.Name()}, file},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertFormatAction(t, test.args, func(cfg format.Config, _ logr.Logger) error {
+				reader, err := cfg.Input()
+				assert.Nil(t, err)
+				assert.Equal(t, test.file.Name(), reader.(*os.File).Name())
+				return nil
+			})
+		})
+	}
+}
+
+func TestFormatCommand_Formats(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		formats []string
+	}{
+		{"default", []string{"format"}, []string{text.Name}},
+		{"single", []string{"format", "-f", "raw"}, []string{raw.Name}},
+		{"multiple", []string{"format", "-f", "raw", "-f", "zbase32"}, []string{raw.Name, zbase32.Name}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertFormatAction(t, test.args, func(cfg format.Config, _ logr.Logger) error {
+				formats, err := cfg.Formats()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(test.formats) != len(formats) {
+					t.Fatalf("expected %d formats, got %d", len(test.formats), len(formats))
+				}
+				for i, name := range test.formats {
+					assert.Equal(t, name, formats[i].Name())
+				}
+				return nil
+			})
+		})
+	}
+}

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -1,0 +1,84 @@
+package internal_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/bketelsen/logr"
+	"github.com/corvus-ch/horcrux/format"
+	"github.com/corvus-ch/horcrux/format/raw"
+	"github.com/corvus-ch/horcrux/format/text"
+	"github.com/corvus-ch/horcrux/format/zbase32"
+	"github.com/stretchr/testify/assert"
+)
+
+type inputTests map[string]struct {
+	args []string
+	file *os.File
+}
+
+type formatTests map[string]struct {
+	args    []string
+	formats []string
+}
+
+func newInputTests(action string, file *os.File) inputTests {
+	return inputTests{
+		"default": {[]string{action}, os.Stdin},
+		"stdin":   {[]string{action, "--", "-"}, os.Stdin},
+		"file":    {[]string{action, "--", file.Name()}, file},
+	}
+}
+
+func newFormatsTests(action string) formatTests {
+	return formatTests{
+		"default":  {[]string{action}, []string{text.Name}},
+		"single":   {[]string{action, "-f", "raw"}, []string{raw.Name}},
+		"multiple": {[]string{action, "-f", "raw", "-f", "zbase32"}, []string{raw.Name, zbase32.Name}},
+	}
+}
+
+func tmpFile(t *testing.T) *os.File {
+	file, err := ioutil.TempFile("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return file
+}
+
+func assertFormats(t *testing.T, cfg format.Config, testFormats []string) {
+	formats, err := cfg.Formats()
+	assert.NoError(t, err)
+	assert.Equal(t, len(testFormats), len(formats))
+	for i, name := range testFormats {
+		assert.Equal(t, name, formats[i].Name())
+	}
+}
+
+func inputTest(t *testing.T, action string) {
+	file := tmpFile(t)
+	defer os.Remove(file.Name())
+	for name, test := range newInputTests(action, file) {
+		t.Run(name, func(t *testing.T) {
+			assertFormatAction(t, test.args, func(cfg format.Config, _ logr.Logger) error {
+				reader, err := cfg.Input()
+				assert.NoError(t, err)
+				assert.Equal(t, test.file.Name(), reader.(*os.File).Name())
+				return nil
+			})
+		})
+	}
+}
+
+func formatTest(t *testing.T, action string) {
+	for name, test := range newFormatsTests(action) {
+		t.Run(name, func(t *testing.T) {
+			assertFormatAction(t, test.args, func(cfg format.Config, _ logr.Logger) error {
+				assertFormats(t, cfg, test.formats)
+				return nil
+			})
+		})
+	}
+}


### PR DESCRIPTION
Added a sub command that produces the same output as `create` but does not do the shamir splitting.